### PR TITLE
added static

### DIFF
--- a/raylib-beef/BeefProj.toml
+++ b/raylib-beef/BeefProj.toml
@@ -56,3 +56,16 @@ LibPaths = ["$(ProjectDir)\\libs\\linux_x64\\libraylib.a"]
 
 [Configs.StaticTest.Linux64]
 LibPaths = ["$(ProjectDir)\\libs\\_x64\\libraylib.a"]
+
+
+[Configs.StaticDebug.Win64]
+OtherLinkFlags = "$(LinkFlags) -libpath:\"$(ProjectDir)/libs/libs_x64\""
+LibPaths = ["$(ProjectDir)\\libs\\libs_x64\\staticraylib.lib"]
+
+[Configs.StaticRelease.Win64]
+OtherLinkFlags = "$(LinkFlags) -libpath:\"$(ProjectDir)/libs/libs_x64\""
+LibPaths = ["$(ProjectDir)\\libs\\libs_x64\\staticraylib.lib"]
+
+[Configs.StaticTest.Win64]
+OtherLinkFlags = "$(LinkFlags) -libpath:\"$(ProjectDir)/libs/libs_x64\""
+LibPaths = ["$(ProjectDir)\\libs\\libs_x64\\staticraylib.lib"]


### PR DESCRIPTION
This adds the option to compile statically for windows.
Simply change the config.
Also the project which depends on raylib needs to change its build settings for C Library and Beef Library to:
C Library -> Dynamic
Beef Library -> Static

The binary is the official msvcrt lib distributed on the raylib release page.

