### PR TITLE
Fix issue with having to change project settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 BeefLang bindings for **Raylib 5.0**.
 
-> **Note**: OS is limited to Windows & WebAssembly right now, I see no reason why this wouldn't work on other platforms, though. I guess only one way to find out.
-
 ## Example
 ```cs
 using System;
@@ -69,12 +67,6 @@ class Program
 On Windows, default linking is set to dynamically link to raylib. This is because of some weird linking problems with MSVC. You can change that by selecting a different project configuration for raylib-beef in the **Workspace** settings. You can select from **StaticDebug** and **StaticRelease**.
 
 ![image](https://github.com/Starpelly/raylib-beef/assets/24588691/d78c5e3f-62ac-4927-89c2-7e73b1262ed7)
-
-Then set your app's build settings to:
-* C Library: Dynamic
-* Beef Library: Static
-
-![image](https://github.com/Starpelly/raylib-beef/assets/24588691/9a0e1f4d-6291-4378-9a1f-708a81e5c149)
 
 
 ## More Links

--- a/raylib-beef/BeefProj.toml
+++ b/raylib-beef/BeefProj.toml
@@ -60,12 +60,12 @@ LibPaths = ["$(ProjectDir)\\libs\\_x64\\libraylib.a"]
 
 [Configs.StaticDebug.Win64]
 OtherLinkFlags = "$(LinkFlags) -libpath:\"$(ProjectDir)/libs/libs_x64\""
-LibPaths = ["$(ProjectDir)\\libs\\libs_x64\\staticraylib.lib"]
+LibPaths = ["$(ProjectDir)\\libs\\libs_x64\\staticraylib.lib", "user32.lib", "gdi32.lib", "windowsapp.lib", "shell32.lib"]
 
 [Configs.StaticRelease.Win64]
 OtherLinkFlags = "$(LinkFlags) -libpath:\"$(ProjectDir)/libs/libs_x64\""
-LibPaths = ["$(ProjectDir)\\libs\\libs_x64\\staticraylib.lib"]
+LibPaths = ["$(ProjectDir)\\libs\\libs_x64\\staticraylib.lib", "user32.lib", "gdi32.lib", "windowsapp.lib", "shell32.lib"]
 
 [Configs.StaticTest.Win64]
 OtherLinkFlags = "$(LinkFlags) -libpath:\"$(ProjectDir)/libs/libs_x64\""
-LibPaths = ["$(ProjectDir)\\libs\\libs_x64\\staticraylib.lib"]
+LibPaths = ["$(ProjectDir)\\libs\\libs_x64\\staticraylib.lib", "user32.lib", "gdi32.lib", "windowsapp.lib", "shell32.lib"]


### PR DESCRIPTION
This should fix the issue we discussed yesterday.
There are two requirements to fixing it.
1: Compile the raylib.lib file using the /MT flag instead of the flag its normally compiled with
2: Manually link the winapi libraries that glfw depends on to run

You should now be able to compile statically on windows without those issues